### PR TITLE
Fix: Scroll en la pagina en lugar del menu

### DIFF
--- a/hangman/hangman.css
+++ b/hangman/hangman.css
@@ -24,7 +24,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/hangman/hangman.css
+++ b/hangman/hangman.css
@@ -24,6 +24,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/index.css
+++ b/index.css
@@ -3,7 +3,7 @@ body{
   font-family:'Gotham Rounded', 'Nunito Sans',sans-serif;
   background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
   min-height:100vh;
-  min-height:100svh;
+  min-height:100dvh;
   display:flex;
   flex-direction:column;
   align-items:center;

--- a/index.css
+++ b/index.css
@@ -3,6 +3,7 @@ body{
   font-family:'Gotham Rounded', 'Nunito Sans',sans-serif;
   background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
   min-height:100vh;
+  min-height:100svh;
   display:flex;
   flex-direction:column;
   align-items:center;

--- a/memory_board/memory_board.css
+++ b/memory_board/memory_board.css
@@ -23,7 +23,7 @@ body {
     font-family: 'Gotham Rounded','Gotham Rounded', 'Nunito Sans', sans-serif;
     background: linear-gradient(135deg, #fff 0%, #e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/memory_board/memory_board.css
+++ b/memory_board/memory_board.css
@@ -23,6 +23,7 @@ body {
     font-family: 'Gotham Rounded','Gotham Rounded', 'Nunito Sans', sans-serif;
     background: linear-gradient(135deg, #fff 0%, #e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/quick_sort/quick_sort.css
+++ b/quick_sort/quick_sort.css
@@ -41,7 +41,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/quick_sort/quick_sort.css
+++ b/quick_sort/quick_sort.css
@@ -41,6 +41,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/riddle_game/riddle_game.css
+++ b/riddle_game/riddle_game.css
@@ -16,6 +16,7 @@
     font-family:'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height:100vh;
+    min-height:100svh;
     display:flex;
     flex-direction:column;
     align-items:center;

--- a/riddle_game/riddle_game.css
+++ b/riddle_game/riddle_game.css
@@ -16,7 +16,7 @@
     font-family:'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height:100vh;
-    min-height:100svh;
+    min-height:100dvh;
     display:flex;
     flex-direction:column;
     align-items:center;

--- a/sequence_game/sequence_game.css
+++ b/sequence_game/sequence_game.css
@@ -22,7 +22,7 @@
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/sequence_game/sequence_game.css
+++ b/sequence_game/sequence_game.css
@@ -22,6 +22,7 @@
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/simon_says/simon_says.css
+++ b/simon_says/simon_says.css
@@ -33,6 +33,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/simon_says/simon_says.css
+++ b/simon_says/simon_says.css
@@ -33,7 +33,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/simple_math/simple_math.css
+++ b/simple_math/simple_math.css
@@ -23,6 +23,7 @@
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/simple_math/simple_math.css
+++ b/simple_math/simple_math.css
@@ -23,7 +23,7 @@
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/true_or_false/true_or_false.css
+++ b/true_or_false/true_or_false.css
@@ -19,7 +19,7 @@ body {
   font-family: 'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
   min-height: 100vh;
-  min-height: 100svh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -161,7 +161,7 @@ body {
 }
 .modal-content h3{ font-size: 1.6rem; margin-bottom: 10px; font-weight: 900; color: var(--text); }
 .result-stats{ color: #333; font-weight: 800; margin-bottom: 12px; }
-.wrong-list{ color: #333; max-height: 45vh;;max-height: 45svh; overflow: auto; padding-right: 6px; }
+.wrong-list{ color: #333; max-height: 45vh;;max-height: 45dvh; overflow: auto; padding-right: 6px; }
 .wrong-item{ background: #fff; border-left: 4px solid var(--err); padding: 10px 12px; border-radius: 10px; margin-bottom: 10px; box-shadow: 0 2px 8px rgba(0,0,0,.06); }
 .wrong-item .phrase{ font-weight: 900; margin-bottom: 4px; }
 .wrong-item .explanation{ opacity: .9; }
@@ -238,7 +238,7 @@ footer p{ margin:0; padding:8px 12px; background: rgba(255,255,255,.35); border-
   }
   .results-modal h3 { font-size: 3rem; margin-bottom: 28px; }
   .result-stats { font-size: 2rem; margin-bottom: 36px; }
-  .wrong-list { font-size: 1.6rem; max-height: 50vh;max-height: 50svh; }
+  .wrong-list { font-size: 1.6rem; max-height: 50vh;max-height: 50dvh; }
   .modal-buttons { gap: 28px; }
   .modal-btn {
     padding: 22px 36px;

--- a/true_or_false/true_or_false.css
+++ b/true_or_false/true_or_false.css
@@ -19,6 +19,7 @@ body {
   font-family: 'Gotham Rounded', 'Nunito Sans', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   background:linear-gradient(135deg,#fff 0%,#e0e0e0 100%);
   min-height: 100vh;
+  min-height: 100svh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -160,7 +161,7 @@ body {
 }
 .modal-content h3{ font-size: 1.6rem; margin-bottom: 10px; font-weight: 900; color: var(--text); }
 .result-stats{ color: #333; font-weight: 800; margin-bottom: 12px; }
-.wrong-list{ color: #333; max-height: 45vh; overflow: auto; padding-right: 6px; }
+.wrong-list{ color: #333; max-height: 45vh;;max-height: 45svh; overflow: auto; padding-right: 6px; }
 .wrong-item{ background: #fff; border-left: 4px solid var(--err); padding: 10px 12px; border-radius: 10px; margin-bottom: 10px; box-shadow: 0 2px 8px rgba(0,0,0,.06); }
 .wrong-item .phrase{ font-weight: 900; margin-bottom: 4px; }
 .wrong-item .explanation{ opacity: .9; }
@@ -237,7 +238,7 @@ footer p{ margin:0; padding:8px 12px; background: rgba(255,255,255,.35); border-
   }
   .results-modal h3 { font-size: 3rem; margin-bottom: 28px; }
   .result-stats { font-size: 2rem; margin-bottom: 36px; }
-  .wrong-list { font-size: 1.6rem; max-height: 50vh; }
+  .wrong-list { font-size: 1.6rem; max-height: 50vh;max-height: 50svh; }
   .modal-buttons { gap: 28px; }
   .modal-btn {
     padding: 22px 36px;

--- a/word_search/word_search.css
+++ b/word_search/word_search.css
@@ -23,7 +23,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background: linear-gradient(135deg, #fff 0%, #e0e0e0 100%);
     min-height: 100vh;
-    min-height: 100svh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/word_search/word_search.css
+++ b/word_search/word_search.css
@@ -23,6 +23,7 @@ body {
     font-family: 'Gotham Rounded', 'Nunito Sans', sans-serif;
     background: linear-gradient(135deg, #fff 0%, #e0e0e0 100%);
     min-height: 100vh;
+    min-height: 100svh;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
**Descripcion**: En ciertos casos el usuario intenta scrollear en el menu de navegacion de los juegos y se produce un scroll en el main tag en lugar de la lista de los juegos.

**Cambios realizados**: Se agrego una propiedad min-height: 100dvh en todos los juegos y en el menu principal. El height de los main tag en cada ruta era mas alto que el viewport, ya que la unidad vh no considera la barra de direcciones del navegador, entonces provocaba un overflow.

<img width="299" height="168" alt="image" src="https://github.com/user-attachments/assets/85102bc1-b40c-467e-91d7-65bb45227d89" />